### PR TITLE
pypaw requires an older version of obspy

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,7 @@ Pypaw has dependancies on the following packages:
 #### 4. install obspy using conda
 
   ```
-  conda install -c obspy obspy
+  conda install -c obspy obspy=1.0.3
   ```
 
 #### 5. Install pytomo3d.

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "seismology", "tomography", "adjoint", "signal", "inversion", "window"
     ],
     install_requires=[
-        "numpy", "obspy>=1.0.0", "flake8>=3.0", "pytest", "nose",
+        "numpy", "obspy==1.0.3", "flake8>=3.0", "pytest", "nose",
         "future>=0.14.1", "pytomo3d", "pyasdf", "pyyaml", "spaceweight"
     ],
     entry_points={


### PR DESCRIPTION
This is a temporary fix so that Carl's group can use your tools.  In the long run you'll either need to stop maintaining separate forks of Lion's packages, or else be prepared for repeated compatibility issues of this type.